### PR TITLE
Added User-Agent to the request header for scrapeUrl method

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -33,6 +33,9 @@ function scrapeHtml(html, rules, url, headers) {
 function scrapeUrl(url, rules) {
   let request = popsicle.request({
     url,
+    headers: {
+      'User-Agent': 'ScrapeMeta'
+    },
     options: {
       jar: process.browser ? null : popsicle.jar()
     }


### PR DESCRIPTION
For some websites/urls that are scraped, if there is no User-Agent header, it returns error such as a 403 Forbidden status. Adding User-Agent header fixes this.